### PR TITLE
Update go.mod to Go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/ibmruntimes/go-recordio
 
-go 1.16
+go 1.18


### PR DESCRIPTION
Update go.mod to enable parameters available in Go 1.18